### PR TITLE
Return items and errors in fetchArchievedItemsAtPage blocks

### DIFF
--- a/CloudApp SDK/CAAPIManager.h
+++ b/CloudApp SDK/CAAPIManager.h
@@ -27,22 +27,22 @@ extern NSString *const bookmarkURLKey;
 - (void)fetchItemsAtPage:(NSInteger)page
     numberOfItemsPerPage:(NSInteger)numberOfItems
                     type:(CAItemType)type
-                 success:(void (^)())success
+                 success:(void (^)(NSArray<CAItem *> *items))success
                  failure:(void (^)(NSError *error))failure;
 
 - (void)fetchItemsAtPage:(NSInteger)page
     numberOfItemsPerPage:(NSInteger)numberOfItems
                   source:(NSString *)source
-                 success:(void (^)())success
+                 success:(void (^)(NSArray<CAItem *> *items))success
                  failure:(void (^)(NSError *error))failure;
 
 - (void)fetchArchivedItemsAtPage:(NSInteger)page success:(void (^)(NSArray<CAItem *> *items))success failure:(void (^)(NSError *error))failure;
 
 - (void)fetchArchievedItemsAtPage:(NSInteger)page
-             numberOfItemsPerPage:(NSInteger)numberOfItems
-                             type:(CAItemType)type
-                          success:(void (^)(NSArray<CAItem *> *items))success
-                          failure:(void (^)(NSError *error))failure;
+     numberOfItemsPerPage:(NSInteger)numberOfItems
+                     type:(CAItemType)type
+                  success:(void (^)(NSArray<CAItem *> *items))success
+                  failure:(void (^)(NSError *error))failure;
 
 - (void)fetchItemFavoriteStatus:(CAItem *)item success:(void (^)(CAItem *item))success failure:(void (^)(NSError *error))failure;
 

--- a/CloudApp SDK/CAAPIManager.m
+++ b/CloudApp SDK/CAAPIManager.m
@@ -173,20 +173,20 @@ NSString *const bookmarkURLKey  = @"redirect_url";
 }
 
 - (void)fetchItemsAtPage:(NSInteger)page
-    numberOfItemsPerPage:(NSInteger)numberOfItems
-                    type:(CAItemType)type
-                 success:(void (^)())success
-                 failure:(void (^)(NSError *error))failure {
+        numberOfItemsPerPage:(NSInteger)numberOfItems
+                        type:(CAItemType)type
+                     success:(void (^)(NSArray<CAItem *> *items))success
+                     failure:(void (^)(NSError *error))failure {
     NSDictionary *parameters = @{kPage:@(page),kItemsPerPage:@(numberOfItems),kType:[CAItem apiValueForItemType:type]};
     [[CANetworkManager sharedInstance] getRequestWithURL:[CANetworkManager secureUrlWithExtension:itemsExtension parameters:parameters]
                                               completion:[self completionBlockForItemsWithSuccess:success failure:failure]];
 }
 
 - (void)fetchItemsAtPage:(NSInteger)page
-    numberOfItemsPerPage:(NSInteger)numberOfItems
-                  source:(NSString *)source
-                 success:(void (^)())success
-                 failure:(void (^)(NSError *error))failure {
+        numberOfItemsPerPage:(NSInteger)numberOfItems
+                      source:(NSString *)source
+                     success:(void (^)(NSArray<CAItem *> *items))success
+                     failure:(void (^)(NSError *error))failure {
     NSDictionary *parameters = @{kPage:@(page),kItemsPerPage:@(numberOfItems),kSource:source};
     [[CANetworkManager sharedInstance] getRequestWithURL:[CANetworkManager secureUrlWithExtension:itemsExtension parameters:parameters]
                                               completion:[self completionBlockForItemsWithSuccess:success failure:failure]];


### PR DESCRIPTION
I assume this was just an oversight.  This passes back the requested items or error in the completion blocks.